### PR TITLE
feat: Fix type errors and failing tests

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,44 +9,39 @@ import type { User, Classroom, ConceptMap, ProjectSubmission } from '@/types';
 
 import { UserRole, ProjectSubmissionStatus } from '@/types';
 
-export const MOCK_STUDENT_USER_V3: User = {
+export const MOCK_STUDENT_USER: User = {
   id: 'student-mock-v3-s001',
   name: 'Alpha Student (Bypass V3)',
   email: 'alphastudent.bypass.v3@example.com',
   role: UserRole.STUDENT,
 };
 
-export const MOCK_TEACHER_USER_V3: User = {
+export const MOCK_TEACHER_USER: User = {
   id: 'teacher-mock-v3-t001',
   name: 'Bravo Teacher (Bypass V3)',
   email: 'bravoteacher.bypass.v3@example.com',
   role: UserRole.TEACHER,
 };
 
-export const MOCK_ADMIN_USER_V3: User = {
+export const MOCK_ADMIN_USER: User = {
   id: 'admin-mock-v3-a001',
   name: 'Charlie Admin (Bypass V3)',
   email: 'charlieadmin.bypass.v3@example.com',
   role: UserRole.ADMIN,
 };
 
-// Default exports for easier use in AuthContext if only one set of mocks is primarily used
-export const MOCK_STUDENT_USER = MOCK_STUDENT_USER_V3;
-export const MOCK_TEACHER_USER = MOCK_TEACHER_USER_V3;
-export const MOCK_ADMIN_USER = MOCK_ADMIN_USER_V3;
-
 export const MOCK_USERS: User[] = [
-  MOCK_STUDENT_USER_V3,
-  MOCK_TEACHER_USER_V3,
-  MOCK_ADMIN_USER_V3,
+  MOCK_STUDENT_USER,
+  MOCK_TEACHER_USER,
+  MOCK_ADMIN_USER,
 ];
 
-export const MOCK_CLASSROOM_SHARED_V3: Classroom = {
+export const MOCK_CLASSROOM_SHARED: Classroom = {
   id: 'class-shared-v3-cs01',
   name: 'Bypass Shared Classroom V3',
-  teacherId: MOCK_TEACHER_USER_V3.id,
-  teacherName: MOCK_TEACHER_USER_V3.name,
-  studentIds: [MOCK_STUDENT_USER_V3.id, 'another-mock-student-v3-s002'],
+  teacherId: MOCK_TEACHER_USER.id,
+  teacherName: MOCK_TEACHER_USER.name,
+  studentIds: [MOCK_STUDENT_USER.id, 'another-mock-student-v3-s002'],
   inviteCode: 'BYPASSV3',
   description: 'A V3 classroom for bypass testing where student is enrolled.',
   subject: 'Advanced Bypassology V3',
@@ -54,11 +49,11 @@ export const MOCK_CLASSROOM_SHARED_V3: Classroom = {
   enableStudentAiAnalysis: false,
 };
 
-export const MOCK_CLASSROOM_TEACHER_OWNED_V3: Classroom = {
+export const MOCK_CLASSROOM_TEACHER_OWNED: Classroom = {
   id: 'class-teacher-owned-v3-ct01',
   name: 'Bypass Teacher Classroom V3',
-  teacherId: MOCK_TEACHER_USER_V3.id,
-  teacherName: MOCK_TEACHER_USER_V3.name,
+  teacherId: MOCK_TEACHER_USER.id,
+  teacherName: MOCK_TEACHER_USER.name,
   studentIds: ['mock-v3-s003', 'mock-v3-s004'],
   inviteCode: 'TEACHV3',
   description: 'A V3 classroom owned by the mock teacher.',
@@ -68,35 +63,35 @@ export const MOCK_CLASSROOM_TEACHER_OWNED_V3: Classroom = {
 };
 
 export const MOCK_CLASSROOMS_STORE: Classroom[] = [
-  MOCK_CLASSROOM_SHARED_V3,
-  MOCK_CLASSROOM_TEACHER_OWNED_V3,
+  MOCK_CLASSROOM_SHARED,
+  MOCK_CLASSROOM_TEACHER_OWNED,
 ];
 export const MOCK_CLASSROOM_STUDENTS_STORE: Array<{
   classroom_id: string;
   student_id: string;
 }> = [
   {
-    classroom_id: MOCK_CLASSROOM_SHARED_V3.id,
-    student_id: MOCK_STUDENT_USER_V3.id,
+    classroom_id: MOCK_CLASSROOM_SHARED.id,
+    student_id: MOCK_STUDENT_USER.id,
   },
   {
-    classroom_id: MOCK_CLASSROOM_SHARED_V3.id,
+    classroom_id: MOCK_CLASSROOM_SHARED.id,
     student_id: 'another-mock-student-v3-s002',
   },
   {
-    classroom_id: MOCK_CLASSROOM_TEACHER_OWNED_V3.id,
+    classroom_id: MOCK_CLASSROOM_TEACHER_OWNED.id,
     student_id: 'mock-v3-s003',
   },
   {
-    classroom_id: MOCK_CLASSROOM_TEACHER_OWNED_V3.id,
+    classroom_id: MOCK_CLASSROOM_TEACHER_OWNED.id,
     student_id: 'mock-v3-s004',
   },
 ];
 
-export const MOCK_CONCEPT_MAP_STUDENT_V3: ConceptMap = {
+export const MOCK_CONCEPT_MAP_STUDENT: ConceptMap = {
   id: 'map-student-v3-ms01',
   name: 'Student Bypass Map V3 Alpha',
-  ownerId: MOCK_STUDENT_USER_V3.id,
+  ownerId: MOCK_STUDENT_USER.id,
   mapData: {
     nodes: [
       {
@@ -110,15 +105,15 @@ export const MOCK_CONCEPT_MAP_STUDENT_V3: ConceptMap = {
     edges: [],
   },
   isPublic: true,
-  sharedWithClassroomId: MOCK_CLASSROOM_SHARED_V3.id,
+  sharedWithClassroomId: MOCK_CLASSROOM_SHARED.id,
   createdAt: new Date(Date.now() - 86400000 * 2).toISOString(),
   updatedAt: new Date(Date.now() - 86400000).toISOString(),
 };
 
-export const MOCK_CONCEPT_MAP_TEACHER_V3: ConceptMap = {
+export const MOCK_CONCEPT_MAP_TEACHER: ConceptMap = {
   id: 'map-teacher-v3-mt01',
   name: 'Teacher Bypass Map V3 Beta',
-  ownerId: MOCK_TEACHER_USER_V3.id,
+  ownerId: MOCK_TEACHER_USER.id,
   mapData: {
     nodes: [
       {
@@ -132,50 +127,48 @@ export const MOCK_CONCEPT_MAP_TEACHER_V3: ConceptMap = {
     edges: [],
   },
   isPublic: false,
-  sharedWithClassroomId: MOCK_CLASSROOM_TEACHER_OWNED_V3.id,
+  sharedWithClassroomId: MOCK_CLASSROOM_TEACHER_OWNED.id,
   createdAt: new Date(Date.now() - 86400000 * 3).toISOString(),
   updatedAt: new Date().toISOString(),
 };
 
 export const MOCK_CONCEPT_MAPS_STORE: ConceptMap[] = [
-  MOCK_CONCEPT_MAP_STUDENT_V3,
-  MOCK_CONCEPT_MAP_TEACHER_V3,
+  MOCK_CONCEPT_MAP_STUDENT,
+  MOCK_CONCEPT_MAP_TEACHER,
 ];
-// This is the specific map used by useConceptMapDataManager's MOCK_USER_FOR_TESTING_MAPS
-export const MOCK_CONCEPT_MAP_STUDENT = MOCK_CONCEPT_MAP_STUDENT_V3;
 
-export const MOCK_PROJECT_SUBMISSION_STUDENT_V3: ProjectSubmission = {
+export const MOCK_PROJECT_SUBMISSION_STUDENT: ProjectSubmission = {
   id: 'sub-student-v3-sps01',
-  studentId: MOCK_STUDENT_USER_V3.id,
+  studentId: MOCK_STUDENT_USER.id,
   originalFileName: 'final_bypass_project_v3.zip',
   fileSize: 234567,
   fileStoragePath: 'mock/final_bypass_project_v3.zip',
   submissionTimestamp: new Date(Date.now() - 86400000 * 3).toISOString(),
   analysisStatus: ProjectSubmissionStatus.COMPLETED,
   generatedConceptMapId: 'map-from-submission-v3-sgs01',
-  classroomId: MOCK_CLASSROOM_SHARED_V3.id,
+  classroomId: MOCK_CLASSROOM_SHARED.id,
 };
 
-export const MOCK_PROJECT_SUBMISSION_PROCESSING_V3: ProjectSubmission = {
+export const MOCK_PROJECT_SUBMISSION_PROCESSING: ProjectSubmission = {
   id: 'sub-processing-v3-spp01',
-  studentId: MOCK_STUDENT_USER_V3.id,
+  studentId: MOCK_STUDENT_USER.id,
   originalFileName: 'alpha_bypass_project_v3.rar',
   fileSize: 789000,
   fileStoragePath: 'mock/alpha_bypass_project_v3.rar',
   submissionTimestamp: new Date(Date.now() - 86400000).toISOString(),
   analysisStatus: ProjectSubmissionStatus.PROCESSING,
-  classroomId: MOCK_CLASSROOM_SHARED_V3.id,
+  classroomId: MOCK_CLASSROOM_SHARED.id,
 };
 
 export const MOCK_SUBMISSIONS_STORE: ProjectSubmission[] = [
-  MOCK_PROJECT_SUBMISSION_STUDENT_V3,
-  MOCK_PROJECT_SUBMISSION_PROCESSING_V3,
+  MOCK_PROJECT_SUBMISSION_STUDENT,
+  MOCK_PROJECT_SUBMISSION_PROCESSING,
 ];
 
 // This is the critical object for useConceptMapDataManager bypass logic
 export const MOCK_USER_FOR_TESTING_MAPS: { [key: string]: ConceptMap } = {
-  [MOCK_CONCEPT_MAP_STUDENT_V3.id]: MOCK_CONCEPT_MAP_STUDENT_V3,
-  [MOCK_CONCEPT_MAP_TEACHER_V3.id]: MOCK_CONCEPT_MAP_TEACHER_V3,
+  [MOCK_CONCEPT_MAP_STUDENT.id]: MOCK_CONCEPT_MAP_STUDENT,
+  [MOCK_CONCEPT_MAP_TEACHER.id]: MOCK_CONCEPT_MAP_TEACHER,
   // Add other specific mock maps here by their ID if needed for testing other routes
   // e.g., if you had map-from-submission-v3-sgs01 defined as a full ConceptMap object:
   // 'map-from-submission-v3-sgs01': { id: 'map-from-submission-v3-sgs01', name: 'AI Map from Submission V3', ... }

--- a/src/tests/__mocks__/next/navigation.ts
+++ b/src/tests/__mocks__/next/navigation.ts
@@ -1,34 +1,36 @@
+import { vi } from 'vitest';
+
 // Store the actual implementations
-const actualNav = jest.requireActual('next/navigation');
+const actualNav = await vi.importActual('next/navigation');
 
 // Default mock implementations
 let mockRouter = {
-  push: jest.fn(),
-  replace: jest.fn(),
-  forward: jest.fn(),
-  back: jest.fn(),
-  prefetch: jest.fn(),
-  refresh: jest.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  forward: vi.fn(),
+  back: vi.fn(),
+  prefetch: vi.fn(),
+  refresh: vi.fn(),
   // Add any other properties/methods your tests might access on the router object
   // For example, if tests access router.events, router.pathname, etc.
   pathname: '/mock-pathname', // Default pathname
   query: {}, // Default query
   asPath: '/mock-pathname', // Default asPath
   events: {
-    on: jest.fn(),
-    off: jest.fn(),
-    emit: jest.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
   },
 };
 
 let mockPathname = '/mock-pathname';
 let mockSearchParams = new URLSearchParams();
 
-export const useRouter = jest.fn(() => mockRouter);
-export const usePathname = jest.fn(() => mockPathname);
-export const useSearchParams = jest.fn(() => mockSearchParams);
+export const useRouter = vi.fn(() => mockRouter);
+export const usePathname = vi.fn(() => mockPathname);
+export const useSearchParams = vi.fn(() => mockSearchParams);
 
-export const redirect = jest.fn((path: string) => {
+export const redirect = vi.fn((path: string) => {
   // In tests, you might want to check if redirect was called with the correct path
   // instead of actually throwing an error, unless that's part of the test.
   console.log(`MOCK_REDIRECT_CALLED: ${path}`);
@@ -39,7 +41,7 @@ export const redirect = jest.fn((path: string) => {
   return `MOCK_REDIRECT_TO:${path}`;
 });
 
-export const permanentRedirect = jest.fn((path: string) => {
+export const permanentRedirect = vi.fn((path: string) => {
   console.log(`MOCK_PERMANENT_REDIRECT_CALLED: ${path}`);
   return `MOCK_PERMANENT_REDIRECT_TO:${path}`;
 });

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -89,6 +89,7 @@ vi.mock('lucide-react', () => {
     Compass: createIcon('Compass'),
     AlertTriangle: createIcon('AlertTriangle'),
     Info: createIcon('Info'),
+    InfoIcon: createIcon('InfoIcon'),
     MessageSquareDashed: createIcon('MessageSquareDashed'),
     CheckSquare: createIcon('CheckSquare'),
     Edit3: createIcon('Edit3'),


### PR DESCRIPTION
This commit addresses several type errors and failing tests in the codebase.

- **`src/lib/config.ts`**:
  - Cleaned up mock data by removing unused variables and standardizing naming conventions.

- **`src/services/classrooms/classroomService.ts`**:
  - Fixed type errors by updating mock data imports, correcting type assertions, and ensuring proper data transformation from Supabase.

- **`src/services/classrooms/__tests__/classroomService.test.ts`**:
  - Fixed all tests by disabling `BYPASS_AUTH_FOR_TESTING` and correcting mocks for Supabase client methods.

- **`src/tests/setup.ts`**:
  - Added a mock for `InfoIcon` from `lucide-react` to resolve test failures in `AIStagingToolbar.test.tsx`.

- **`src/tests/__mocks__/next/navigation.ts`**:
  - Replaced `jest` APIs with `vitest` equivalents (`vi.importActual` and `vi.fn()`) to resolve `jest is not defined` errors.

Despite these fixes, several tests are still failing. The remaining issues include:
- Mock errors in `useConceptMapDataManager.test.ts` related to the Zustand store.
- `jest is not defined` errors persisting in some files.
- Import resolution failure for `graphology-traversal/bfs`.
- `genkit is not defined` error in `project-analyzer-tool.test.ts`.
- Algorithmic/logical errors in `dagre` and `layout-utils` tests.
- Integration test failures in `classroom-management-flow.test.ts` due to `BYPASS_AUTH_FOR_TESTING`.

Further work is required to address these remaining test failures.