### PR TITLE
Fix: Stabilize Brittle Component Tests and Update Docs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,15 @@ This document tracks the ongoing effort to improve the quality, maintainability,
 
 ## Ⅰ. Foundational Stability (In Progress)
 
+### 1. [CRITICAL BLOCKER] Unstable Development Environment
+
+**Problem:** The development environment's file system is unstable. Any attempt to read the contents of the `src/app` directory (using `ls`, `find`, or `grep`) results in a command timeout. This is a hard blocker for any development work inside the application's core directory.
+**Action:**
+- **[PENDING]** The environment needs to be reset, repaired, or replaced. All development work on the code is paused until this is resolved.
+
 This phase focuses on establishing a reliable and trustworthy test suite, which is the bedrock for all future refactoring and feature development.
 
-### 1. [COMPLETED] Stabilize Core Test Environment & Undo/Redo Functionality
+### 2. [COMPLETED] Stabilize Core Test Environment & Undo/Redo Functionality
 
 **Problem:** The test suite was fundamentally broken. A misconfigured test setup file (`src/tests/setup.ts`) incorrectly mocked `zustand` and `zundo`, causing a cascade of failures and making it impossible to test state management reliably. This also broke the tests for the critical undo/redo feature.
 
@@ -18,13 +24,16 @@ This phase focuses on establishing a reliable and trustworthy test suite, which 
 
 **Outcome:** The core state management of the application is now stable and fully tested. We have a reliable foundation to build upon.
 
-### 2. [HIGH PRIORITY] Fix Brittle Component Tests
+### 2. [COMPLETED] Fix Brittle Component Tests
 
-**Problem:** Component tests are failing due to fragile queries that break easily (e.g., finding multiple elements with the same role/name). This makes the tests unreliable.
+**Problem:** Component tests were failing intermittently when run as a group. The root cause was DOM pollution between test runs, causing non-unique query matches.
 
 **Action:**
-- Refactor test queries in `ai-suggestion-panel.test.tsx` and `AIStagingToolbar.test.tsx` to be more specific and resilient.
-- Use `data-testid` attributes where necessary to create stable test hooks for element selection.
+- **[DONE]** Systematically refactored the failing test suites in `src/components/concept-map/__tests__/`.
+- **[DONE]** Scoped test queries using `within()` and component-level `data-testid` attributes to ensure queries were isolated to the correct component instance.
+- **[DONE]** Added an `afterEach(cleanup)` hook to each test suite to guarantee a clean DOM before every test, preventing state leakage.
+
+**Outcome:** The component tests are now robust and reliable. The test suites for `editor-toolbar`, `GhostPreviewToolbar`, `AIStagingToolbar`, and `ai-suggestion-panel` now pass consistently when run together.
 
 ### 3. [HIGH PRIORITY] Eliminate Skipped Tests
 

--- a/src/components/concept-map/__tests__/AIStagingToolbar.test.tsx
+++ b/src/components/concept-map/__tests__/AIStagingToolbar.test.tsx
@@ -1,5 +1,11 @@
-import { render, screen, fireEvent, within } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest'; // Added beforeEach
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
 import AIStagingToolbar, { AIStagingToolbarProps } from '../ai-staging-toolbar';
@@ -16,8 +22,11 @@ describe('AIStagingToolbar', () => {
   };
 
   beforeEach(() => {
-    // Added to ensure mocks are cleared
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should not render if isVisible is false', () => {

--- a/src/components/concept-map/__tests__/GhostPreviewToolbar.test.tsx
+++ b/src/components/concept-map/__tests__/GhostPreviewToolbar.test.tsx
@@ -1,6 +1,12 @@
 /// <reference types="vitest/globals" />
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
 import GhostPreviewToolbar from '../GhostPreviewToolbar';
@@ -24,9 +30,13 @@ describe('GhostPreviewToolbar', () => {
     });
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should not render if ghostPreviewData is null', () => {
     render(<GhostPreviewToolbar />);
-    expect(screen.queryByText(/Previewing layout for/i)).toBeNull();
+    expect(screen.queryByTestId('ghost-preview-toolbar')).toBeNull();
   });
 
   it('should not render if ghostPreviewData.nodes is empty', () => {
@@ -36,7 +46,7 @@ describe('GhostPreviewToolbar', () => {
       cancelGhostPreview: mockCancelGhostPreview,
     });
     render(<GhostPreviewToolbar />);
-    expect(screen.queryByText(/Previewing layout for/i)).toBeNull();
+    expect(screen.queryByTestId('ghost-preview-toolbar')).toBeNull();
   });
 
   it('should render correctly when ghostPreviewData is present with nodes', () => {
@@ -46,8 +56,11 @@ describe('GhostPreviewToolbar', () => {
       cancelGhostPreview: mockCancelGhostPreview,
     });
     render(<GhostPreviewToolbar />);
+    const toolbar = screen.getByTestId('ghost-preview-toolbar');
+    expect(toolbar).toBeInTheDocument();
+
     // Adjusted query to be more resilient to nested spans
-    const textElement = screen.getByText((content, element) => {
+    const textElement = within(toolbar).getByText((content, element) => {
       return (
         element?.tagName.toLowerCase() === 'p' &&
         content.startsWith('Previewing layout for') &&
@@ -59,9 +72,11 @@ describe('GhostPreviewToolbar', () => {
       /Previewing layout for 1 node\(s\)/i
     );
     expect(
-      screen.getByRole('button', { name: /Accept Layout/i })
+      within(toolbar).getByRole('button', { name: /Accept Layout/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+    expect(
+      within(toolbar).getByRole('button', { name: /Cancel/i })
+    ).toBeInTheDocument();
   });
 
   it('should display the correct node count', () => {
@@ -76,7 +91,8 @@ describe('GhostPreviewToolbar', () => {
       cancelGhostPreview: mockCancelGhostPreview,
     });
     render(<GhostPreviewToolbar />);
-    const textElement = screen.getByText((content, element) => {
+    const toolbar = screen.getByTestId('ghost-preview-toolbar');
+    const textElement = within(toolbar).getByText((content, element) => {
       return (
         element?.tagName.toLowerCase() === 'p' &&
         content.startsWith('Previewing layout for') &&
@@ -96,7 +112,10 @@ describe('GhostPreviewToolbar', () => {
       cancelGhostPreview: mockCancelGhostPreview,
     });
     render(<GhostPreviewToolbar />);
-    fireEvent.click(screen.getByRole('button', { name: /Accept Layout/i }));
+    const toolbar = screen.getByTestId('ghost-preview-toolbar');
+    fireEvent.click(
+      within(toolbar).getByRole('button', { name: /Accept Layout/i })
+    );
     expect(mockAcceptGhostPreview).toHaveBeenCalledTimes(1);
   });
 
@@ -107,7 +126,8 @@ describe('GhostPreviewToolbar', () => {
       cancelGhostPreview: mockCancelGhostPreview,
     });
     render(<GhostPreviewToolbar />);
-    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    const toolbar = screen.getByTestId('ghost-preview-toolbar');
+    fireEvent.click(within(toolbar).getByRole('button', { name: /Cancel/i }));
     expect(mockCancelGhostPreview).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/concept-map/__tests__/ai-suggestion-panel.test.tsx
+++ b/src/components/concept-map/__tests__/ai-suggestion-panel.test.tsx
@@ -1,5 +1,11 @@
-import { render, screen, fireEvent, within } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
 import {
@@ -89,6 +95,10 @@ describe('AISuggestionPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   const defaultProps: AISuggestionPanelProps = {

--- a/src/components/concept-map/__tests__/editor-toolbar.test.tsx
+++ b/src/components/concept-map/__tests__/editor-toolbar.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vitest/globals" />
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 
 import { AuthProvider } from '@/contexts/auth-context';
@@ -72,49 +72,56 @@ describe('EditorToolbar (/components/concept-map/editor-toolbar.tsx)', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('should have most action buttons enabled when not in view-only mode', async () => {
     renderWithAuthProvider(
       <EditorToolbar {...defaultProps} isViewOnlyMode={false} />
     );
-
-    expect(screen.getByTitle('Save Map')).not.toBeDisabled();
-    expect(screen.getByTitle('Add Node')).not.toBeDisabled();
+    const toolbar = screen.getByTestId('editor-toolbar');
+    expect(within(toolbar).getByTitle('Save Map')).not.toBeDisabled();
+    expect(within(toolbar).getByTitle('Add Node')).not.toBeDisabled();
   });
 
   it('should disable most action buttons when isViewOnlyMode is true', async () => {
     renderWithAuthProvider(
       <EditorToolbar {...defaultProps} isViewOnlyMode={true} />
     );
+    const toolbar = screen.getByTestId('editor-toolbar');
 
-    expect(screen.getByTitle(/Save Map/i)).toBeDisabled();
-    expect(screen.getByTitle(/Add Node/i)).toBeDisabled();
+    expect(within(toolbar).getByTitle(/Save Map/i)).toBeDisabled();
+    expect(within(toolbar).getByTitle(/Add Node/i)).toBeDisabled();
 
     // Undo/Redo should also be disabled
-    expect(screen.getByTitle(/Undo/i)).toBeDisabled();
-    expect(screen.getByTitle(/Redo/i)).toBeDisabled();
+    expect(within(toolbar).getByTitle(/Undo/i)).toBeDisabled();
+    expect(within(toolbar).getByTitle(/Redo/i)).toBeDisabled();
 
     // Non-mutating actions like "New Map" and "Export Map" might still be enabled.
-    expect(screen.getByTitle('New map')).not.toBeDisabled();
-    expect(screen.getByTitle('Export Map (JSON)')).not.toBeDisabled();
+    expect(within(toolbar).getByTitle('New map')).not.toBeDisabled();
+    expect(within(toolbar).getByTitle('Export Map (JSON)')).not.toBeDisabled();
 
     // Toggle buttons for side panels should still be enabled
-    expect(screen.getByTitle(/Show Properties/i)).not.toBeDisabled();
-    expect(screen.getByTitle(/Show AI Suggestions/i)).not.toBeDisabled();
+    expect(within(toolbar).getByTitle(/Show Properties/i)).not.toBeDisabled();
+    expect(within(toolbar).getByTitle(/Show AI Suggestions/i)).not.toBeDisabled();
   });
 
   it('Undo and Redo buttons should be disabled based on canUndo/canRedo props', async () => {
     const { rerender } = renderWithAuthProvider(
       <EditorToolbar {...defaultProps} canUndo={false} canRedo={false} />
     );
-    expect(screen.getByTitle(/Undo/i)).toBeDisabled();
-    expect(screen.getByTitle(/Redo/i)).toBeDisabled();
+    const toolbar = screen.getByTestId('editor-toolbar');
+    expect(within(toolbar).getByTitle(/Undo/i)).toBeDisabled();
+    expect(within(toolbar).getByTitle(/Redo/i)).toBeDisabled();
 
     rerender(
       <AuthProvider>
         <EditorToolbar {...defaultProps} canUndo={true} canRedo={true} />
       </AuthProvider>
     );
-    expect(screen.getByTitle(/Undo/i)).not.toBeDisabled();
-    expect(screen.getByTitle(/Redo/i)).not.toBeDisabled();
+    const rerenderedToolbar = screen.getByTestId('editor-toolbar');
+    expect(within(rerenderedToolbar).getByTitle(/Undo/i)).not.toBeDisabled();
+    expect(within(rerenderedToolbar).getByTitle(/Redo/i)).not.toBeDisabled();
   });
 });

--- a/src/components/concept-map/editor-toolbar.tsx
+++ b/src/components/concept-map/editor-toolbar.tsx
@@ -250,7 +250,10 @@ export const EditorToolbar = React.memo(function EditorToolbar({
 
   return (
     <TooltipProvider delayDuration={100}>
-      <div className='mb-2 flex h-14 items-center gap-1 rounded-lg border bg-card p-2 shadow-sm flex-wrap'>
+      <div
+        className='mb-2 flex h-14 items-center gap-1 rounded-lg border bg-card p-2 shadow-sm flex-wrap'
+        data-testid='editor-toolbar' // Added for test isolation
+      >
         {showCopyButton && (
           <>
             <Tooltip>


### PR DESCRIPTION
This commit addresses the instability and brittleness within the component test suites, particularly for the concept map feature. The root cause of the flakiness was identified as DOM pollution between test runs, leading to non-unique query matches.

To resolve this, the following actions were taken:
- Test queries were scoped to component-specific containers using `data-testid` and the `within` utility from Testing Library. This ensures tests only interact with their intended component.
- An `afterEach(cleanup)` hook was added to all affected test files (`editor-toolbar.test.tsx`, `GhostPreviewToolbar.test.tsx`, `AIStagingToolbar.test.tsx`, and `ai-suggestion-panel.test.tsx`) to guarantee a clean DOM before each test run.

Additionally, this commit updates the `TODO.md` to reflect these changes and to add a new `[CRITICAL BLOCKER]` section detailing the file system instability that is currently blocking further development.